### PR TITLE
Use correct field separator in keywords.txt

### DIFF
--- a/keywords.txt
+++ b/keywords.txt
@@ -6,13 +6,13 @@
 # Datatypes (KEYWORD1)
 #######################################
 
-DS3231 KEYWORD1
+DS3231	KEYWORD1
 
 #######################################
 # Methods and Functions (KEYWORD2)
 #######################################
 
-begin KEYWORD2
+begin	KEYWORD2
 
 getYear	KEYWORD2
 getMonth	KEYWORD2
@@ -21,8 +21,8 @@ getDow	KEYWORD2
 getHours	KEYWORD2
 getMinutes	KEYWORD2
 getSeconds	KEYWORD2
-getTimeString KEYWORD2
-setTime24
+getTimeString	KEYWORD2
+setTime24	KEYWORD2
 
 setAlarm1	KEYWORD2
 setAlarm2	KEYWORD2


### PR DESCRIPTION
The Arduino IDE requires the use of a single true tab separator between the keyword name and identifier. When spaces are used rather than a true tab, the keyword is not highlighted.

Reference:
https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#keywords